### PR TITLE
Fix wildcard NotFound route

### DIFF
--- a/frontendClean/src/App.jsx
+++ b/frontendClean/src/App.jsx
@@ -14,7 +14,7 @@ export default function App() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/profile" element={<ProtectedUserPage />} />
       <Route path="/user" element={<UserPage />} />
-      <Route path="*" eement={<NotFound />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- Correct wildcard route to render NotFound component

## Testing
- `npm test`
- `cd frontendClean && npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68974afecacc833188e0f8536a861843