### PR TITLE
feat: redirect to profile after login

### DIFF
--- a/frontendClean/src/components/LoginPage.jsx
+++ b/frontendClean/src/components/LoginPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import MainNav from './MainNav';
 import Footer from './Footer';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { setToken } from '../store';
 import '../style/main.css';
 
@@ -9,6 +10,7 @@ function LoginPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const dispatch = useDispatch();
+    const navigate = useNavigate();
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -21,6 +23,7 @@ function LoginPage() {
             const data = await response.json();
             if (response.ok && data.body && data.body.token) {
                 dispatch(setToken(data.body.token));
+                navigate('/profile');
             } else {
                 console.error('Login failed');
             }


### PR DESCRIPTION
## Summary
- use `useNavigate` to redirect to the profile page after login

## Testing
- `npm test`
- `npm --prefix frontendClean run lint`


------
https://chatgpt.com/codex/tasks/task_b_68974eaab48c83319d8c644109e2b569