### PR TITLE
Add labels for user name edit form

### DIFF
--- a/frontendClean/src/components/UserPage.jsx
+++ b/frontendClean/src/components/UserPage.jsx
@@ -62,13 +62,27 @@ function UserPage() {
                     {editing ? (
                         <form className="edit-name-form" onSubmit={handleSubmit}>
                             <div className="input-wrapper">
-                                <input type="text" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+                                <label htmlFor="firstName">First Name</label>
+                                <input
+                                    id="firstName"
+                                    type="text"
+                                    value={firstName}
+                                    onChange={(e) => setFirstName(e.target.value)}
+                                />
                             </div>
                             <div className="input-wrapper">
-                                <input type="text" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+                                <label htmlFor="lastName">Last Name</label>
+                                <input
+                                    id="lastName"
+                                    type="text"
+                                    value={lastName}
+                                    onChange={(e) => setLastName(e.target.value)}
+                                />
                             </div>
                             <button type="submit" className="save-button">Save</button>
-                            <button type="button" className="cancel-button" onClick={() => setEditing(false)}>Cancel</button>
+                            <button type="button" className="cancel-button" onClick={() => setEditing(false)}>
+                                Cancel
+                            </button>
                         </form>
                     ) : (
                         <>

--- a/frontendClean/src/style/main.css
+++ b/frontendClean/src/style/main.css
@@ -262,6 +262,17 @@ body {
     padding: 10px;
 }
 
+.edit-name-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.edit-name-form .input-wrapper {
+    flex: 1;
+    margin-bottom: 0;
+}
+
 .save-button,
 .cancel-button {
     border-color: #00bc77;


### PR DESCRIPTION
## Summary
- add proper labels and ids to the user name edit form
- style edit form to keep fields side-by-side with labels

## Testing
- `npm test`
- `cd frontendClean && npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68974eaf436483319e8baac3cfa901ed