### PR TITLE
Handle profile update errors on UserPage

### DIFF
--- a/frontendClean/src/components/UserPage.jsx
+++ b/frontendClean/src/components/UserPage.jsx
@@ -10,6 +10,7 @@ function UserPage() {
     const [editing, setEditing] = useState(false);
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
+    const [error, setError] = useState('');
 
     useEffect(() => {
         if (!token) {
@@ -38,6 +39,7 @@ function UserPage() {
 
     const handleSubmit = (e) => {
         e.preventDefault();
+        setError('');
         fetch('/profile', {
             method: 'PUT',
             headers: {
@@ -47,11 +49,18 @@ function UserPage() {
             body: JSON.stringify({ firstName, lastName }),
         })
             .then((res) => res.json())
-            .then(() => {
-                setProfile({ firstName, lastName });
-                setEditing(false);
+            .then((data) => {
+                if (data && data.status === 200) {
+                    setProfile({ firstName, lastName });
+                    setEditing(false);
+                } else {
+                    setError('Failed to update profile');
+                }
             })
-            .catch((err) => console.error('Failed to update profile', err));
+            .catch((err) => {
+                console.error('Failed to update profile', err);
+                setError('Failed to update profile');
+            });
     };
 
     return (
@@ -67,6 +76,7 @@ function UserPage() {
                             <div className="input-wrapper">
                                 <input type="text" value={lastName} onChange={(e) => setLastName(e.target.value)} />
                             </div>
+                            {error && <p className="error-message">{error}</p>}
                             <button type="submit" className="save-button">Save</button>
                             <button type="button" className="cancel-button" onClick={() => setEditing(false)}>Cancel</button>
                         </form>


### PR DESCRIPTION
## Summary
- parse backend response and check success before updating profile
- show error message and keep editing form open when update fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68974eb008f88331a5d762d394c17c4a