### PR TITLE
feat: remember me token persistence

### DIFF
--- a/frontendClean/src/components/LoginPage.jsx
+++ b/frontendClean/src/components/LoginPage.jsx
@@ -10,6 +10,7 @@ function LoginPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
+    const [rememberMe, setRememberMe] = useState(false);
     const dispatch = useDispatch();
     const navigate = useNavigate();
 
@@ -25,11 +26,17 @@ function LoginPage() {
             const data = await response.json();
             if (response.ok && data.body && data.body.token) {
                 dispatch(setToken(data.body.token));
+                if (rememberMe) {
+                    localStorage.setItem('token', data.body.token);
+                } else {
+                    localStorage.removeItem('token');
+                }
                 navigate('/profile');
             } else {
                 setError(data.message || 'Login failed');
             }
         } catch (err) {
+            console.error('Error during login', err);
             setError('Error during login');
         }
     };
@@ -61,7 +68,12 @@ function LoginPage() {
                             />
                         </div>
                         <div className="input-remember">
-                            <input type="checkbox" id="remember-me" />
+                            <input
+                                type="checkbox"
+                                id="remember-me"
+                                checked={rememberMe}
+                                onChange={(e) => setRememberMe(e.target.checked)}
+                            />
                             <label htmlFor="remember-me">Remember me</label>
                         </div>
                         <button type="submit" className="sign-in-button">Sign In</button>

--- a/frontendClean/src/components/MainNav.jsx
+++ b/frontendClean/src/components/MainNav.jsx
@@ -40,6 +40,7 @@ function MainNav() {
     }, [token]);
 
     const handleSignOut = () => {
+        localStorage.removeItem('token');
         dispatch(clearToken());
         navigate('/');
     };

--- a/frontendClean/src/store/index.js
+++ b/frontendClean/src/store/index.js
@@ -3,7 +3,7 @@ import { configureStore, createSlice } from '@reduxjs/toolkit';
 const authSlice = createSlice({
   name: 'auth',
   initialState: {
-    token: null,
+    token: localStorage.getItem('token') || null,
   },
   reducers: {
     setToken: (state, action) => {


### PR DESCRIPTION
## Summary
- add remember-me option to login that stores token in localStorage when selected
- hydrate auth token from localStorage on startup
- clear persisted token on sign-out

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a3678b53c833191243a4398eeebca