### PR TITLE
Remove transaction delete endpoint reference

### DIFF
--- a/swaggerTransaction.yaml
+++ b/swaggerTransaction.yaml
@@ -122,19 +122,6 @@ paths:
           description: Données invalides.
         '404':
           description: Transaction non trouvée.
-    delete:
-      summary: Supprimer une transaction
-      parameters:
-        - in: path
-          name: transactionId
-          required: true
-          schema:
-            type: integer
-      responses:
-        '204':
-          description: Transaction supprimée avec succès.
-        '404':
-          description: Transaction non trouvée.
 
 components:
   schemas:


### PR DESCRIPTION
## Summary
- remove DELETE /transactions/{transactionId} definition from Swagger documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a378795e48331aa225e531c469328