### PR TITLE
feat: add user slice and share profile name

### DIFF
--- a/frontendClean/src/components/MainNav.jsx
+++ b/frontendClean/src/components/MainNav.jsx
@@ -1,47 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { clearToken } from '../store';
+import { clearToken, clearUser } from '../store';
 import logo from '../assets/argentBankLogo.png';
 
 function MainNav() {
     const token = useSelector((state) => state.auth.token);
+    const firstName = useSelector((state) => state.user.firstName);
     const dispatch = useDispatch();
     const navigate = useNavigate();
-    const [firstName, setFirstName] = useState('');
-
-    useEffect(() => {
-        const fetchUser = async () => {
-            try {
-                const res = await fetch('http://localhost:3001/api/v1/user/profile', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        Authorization: `Bearer ${token}`,
-                    },
-                });
-                if (res.ok) {
-                    const data = await res.json();
-                    setFirstName(data.body.firstName);
-                } else {
-                    setFirstName('');
-                }
-            } catch (error) {
-                console.error('Failed to fetch user profile', error);
-                setFirstName('');
-            }
-        };
-
-        if (token) {
-            fetchUser();
-        } else {
-            setFirstName('');
-        }
-    }, [token]);
 
     const handleSignOut = () => {
         localStorage.removeItem('token');
         dispatch(clearToken());
+        dispatch(clearUser());
         navigate('/');
     };
 

--- a/frontendClean/src/components/UserPage.jsx
+++ b/frontendClean/src/components/UserPage.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import MainNav from '../components/MainNav';
 import Footer from '../components/Footer';
 import withAuth from '../components/withAuth';
+import { setUser } from '../store';
 
 const API_URL = 'http://localhost:3001/api/v1/user/profile';
 
 function UserPage() {
     const token = useSelector((state) => state.auth.token);
+    const dispatch = useDispatch();
     const [profile, setProfile] = useState({ firstName: '', lastName: '' });
     const [editing, setEditing] = useState(false);
     const [firstName, setFirstName] = useState('');
@@ -28,21 +30,19 @@ function UserPage() {
             .then((res) => res.json())
             .then((data) => {
                 if (data && data.body) {
-                    setProfile({
-                        firstName: data.body.firstName,
-                        lastName: data.body.lastName,
-                    });
-                    setFirstName(data.body.firstName);
-                    setLastName(data.body.lastName);
+                    const { firstName, lastName } = data.body;
+                    setProfile({ firstName, lastName });
+                    setFirstName(firstName);
+                    setLastName(lastName);
+                    dispatch(setUser({ firstName, lastName }));
                 }
             })
             .catch((err) => console.error('Failed to fetch profile', err));
-    }, [token]);
+    }, [token, dispatch]);
 
     const handleSubmit = (e) => {
         e.preventDefault();
         fetch(API_URL, {
-
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
@@ -53,18 +53,14 @@ function UserPage() {
             .then((res) => res.json())
             .then((data) => {
                 if (data && data.body) {
-                    setProfile({
-                        firstName: data.body.firstName,
-                        lastName: data.body.lastName,
-                    });
-                    setFirstName(data.body.firstName);
-                    setLastName(data.body.lastName);
+                    const { firstName: updatedFirst, lastName: updatedLast } = data.body;
+                    setProfile({ firstName: updatedFirst, lastName: updatedLast });
+                    setFirstName(updatedFirst);
+                    setLastName(updatedLast);
+                    dispatch(setUser({ firstName: updatedFirst, lastName: updatedLast }));
                 }
                 setEditing(false);
-                if (data && data.status === 200) {
-                    setProfile({ firstName, lastName });
-                    setEditing(false);
-                } else {
+                if (!(data && data.status === 200)) {
                     setError('Failed to update profile');
                 }
             })

--- a/frontendClean/src/store/index.js
+++ b/frontendClean/src/store/index.js
@@ -17,9 +17,30 @@ const authSlice = createSlice({
 
 export const { setToken, clearToken } = authSlice.actions;
 
+const userSlice = createSlice({
+  name: 'user',
+  initialState: {
+    firstName: '',
+    lastName: '',
+  },
+  reducers: {
+    setUser: (state, action) => {
+      state.firstName = action.payload.firstName;
+      state.lastName = action.payload.lastName;
+    },
+    clearUser: (state) => {
+      state.firstName = '';
+      state.lastName = '';
+    },
+  },
+});
+
+export const { setUser, clearUser } = userSlice.actions;
+
 const store = configureStore({
   reducer: {
     auth: authSlice.reducer,
+    user: userSlice.reducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- add dedicated user slice with setUser and clearUser actions
- dispatch profile data into store and update header via selector
- load user profile after login for immediate header display

## Testing
- `npm test`
- `cd frontendClean && npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a3807c268833196f893f81c09113c