### PR TITLE
style sign-out button in main nav

### DIFF
--- a/frontendClean/src/components/MainNav.jsx
+++ b/frontendClean/src/components/MainNav.jsx
@@ -30,9 +30,9 @@ function MainNav() {
                             <i className="fa fa-user-circle"></i>
                             {' '}{firstName}
                         </Link>
-                        <button className="main-nav-item" onClick={handleSignOut}>
+                        <button className="main-nav-item sign-out-link" onClick={handleSignOut}>
                             <i className="fa fa-sign-out"></i>
-                            {' '}Sign Out
+                            Sign out
                         </button>
                     </>
                 ) : (

--- a/frontendClean/src/style/main.css
+++ b/frontendClean/src/style/main.css
@@ -63,6 +63,24 @@ body {
     text-decoration: underline;
 }
 
+.sign-out-link {
+    display: inline-flex;
+    align-items: center;
+    color: #374151;
+    background: #f3f6fa;
+    font-family: sans-serif;
+    font-size: 14px;
+    padding: 0 8px;
+    border: none;
+    cursor: pointer;
+}
+.sign-out-link i {
+    margin-right: 4px;
+}
+.sign-out-link:hover {
+    color: #1f2937;
+}
+
 .main-nav-logo {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add sign-out-link class to main nav button
- style sign-out button with inline-flex alignment and hover color change

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a3c3bd6608331b3d2ad03858d2da6