### PR TITLE
refactor: enhance user form layout and styling

### DIFF
--- a/frontendClean/src/components/UserPage.jsx
+++ b/frontendClean/src/components/UserPage.jsx
@@ -77,29 +77,37 @@ function UserPage() {
                 <div className="header">
                     {editing ? (
                         <form className="edit-name-form" onSubmit={handleSubmit}>
-                            <div className="input-wrapper">
-                                <label htmlFor="firstName">First Name</label>
-                                <input
-                                    id="firstName"
-                                    type="text"
-                                    value={firstName}
-                                    onChange={(e) => setFirstName(e.target.value)}
-                                />
-                            </div>
-                            <div className="input-wrapper">
-                                <label htmlFor="lastName">Last Name</label>
-                                <input
-                                    id="lastName"
-                                    type="text"
-                                    value={lastName}
-                                    onChange={(e) => setLastName(e.target.value)}
-                                />
+                            <div className="inputs-row">
+                                <div className="input-wrapper">
+                                    <label htmlFor="firstName">First Name</label>
+                                    <input
+                                        id="firstName"
+                                        type="text"
+                                        value={firstName}
+                                        onChange={(e) => setFirstName(e.target.value)}
+                                    />
+                                </div>
+                                <div className="input-wrapper">
+                                    <label htmlFor="lastName">Last Name</label>
+                                    <input
+                                        id="lastName"
+                                        type="text"
+                                        value={lastName}
+                                        onChange={(e) => setLastName(e.target.value)}
+                                    />
+                                </div>
                             </div>
                             {error && <p className="error-message">{error}</p>}
-                            <button type="submit" className="save-button">Save</button>
-                            <button type="button" className="cancel-button" onClick={() => setEditing(false)}>
-                                Cancel
-                            </button>
+                            <div className="button-row">
+                                <button type="submit" className="save-button">Save</button>
+                                <button
+                                    type="button"
+                                    className="cancel-button"
+                                    onClick={() => setEditing(false)}
+                                >
+                                    Cancel
+                                </button>
+                            </div>
                         </form>
                     ) : (
                         <>

--- a/frontendClean/src/style/main.css
+++ b/frontendClean/src/style/main.css
@@ -265,35 +265,73 @@ body {
     font-weight: bold;
     padding: 10px;
 }
-
 .edit-name-form {
+    background: #f3f6fa;
     display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.inputs-row {
+    display: flex;
+    gap: 10px;
+}
+
+@media (max-width: 480px) {
+    .inputs-row {
+        flex-direction: column;
+    }
 }
 
 .edit-name-form .input-wrapper {
-    flex: 1;
-    margin-bottom: 0;
-}
-
-.save-button,
-.cancel-button {
-    border-color: #00bc77;
-    background-color: #00bc77;
-    color: #fff;
-    font-weight: bold;
-    padding: 10px;
-}
-
-.edit-name-form {
     display: flex;
+    flex-direction: column;
+}
+
+.edit-name-form input[type="text"] {
+    width: 180px;
+    height: 28px;
+    border: 1px solid #dcdcdc;
+    border-radius: 4px;
+    background: #fff;
+    padding: 0 8px;
+}
+
+.edit-name-form input[type="text"]::placeholder {
+    color: #ccc;
+}
+
+.edit-name-form input[type="text"]:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #6d28d9;
+}
+
+.button-row {
+    display: flex;
+    flex-wrap: wrap;
     justify-content: center;
-    gap: 1rem;
-    width: 300px;
-    padding: 1rem;
-    border: 1px solid #ccc;
-    margin: 0 auto;
+    margin-top: 1rem;
+}
+
+.button-row button {
+    color: #6d28d9;
+    background: none;
+    border: none;
+    height: 28px;
+    margin: 0 12px;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.button-row button:hover {
+    color: #5b21b6;
+}
+
+.button-row button:focus-visible {
+    outline: 2px solid #6d28d9;
+    outline-offset: 2px;
 }
 
 .header {


### PR DESCRIPTION
## Summary
- align first and last name inputs side-by-side and group Save/Cancel actions
- add responsive styling for inputs and button group with purple-focused states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a3d039e308331a1bd2415a1544d2c