### PR TITLE
style: refine edit-name input appearance

### DIFF
--- a/frontendClean/src/style/main.css
+++ b/frontendClean/src/style/main.css
@@ -293,10 +293,11 @@ body {
 .edit-name-form input[type="text"] {
     width: 180px;
     height: 28px;
-    border: 1px solid #dcdcdc;
-    border-radius: 4px;
+    border: 2px solid #6d28d9;
+    border-radius: 2px;
     background: #fff;
     padding: 0 8px;
+    color: #808080;
 }
 
 .edit-name-form input[type="text"]::placeholder {


### PR DESCRIPTION
## Summary
- refine edit-name input with square corners
- highlight input border with purple and gray text

## Testing
- `npm test`
- `cd frontendClean && npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689a41abafa48331adc09b24eadad48a