### PR TITLE
Ensure consistent styling for edit name buttons

### DIFF
--- a/frontendClean/src/style/main.css
+++ b/frontendClean/src/style/main.css
@@ -318,7 +318,7 @@ body {
 
 .button-row button {
     color: #6d28d9;
-    background: none;
+    background-color: #fff;
     border: 2px solid #6d28d9;
     border-radius: 2px;
     height: 36px;
@@ -326,6 +326,7 @@ body {
     padding: 0 1rem;
     cursor: pointer;
     text-decoration: none;
+    min-width: 120px;
 }
 
 .button-row button:hover {


### PR DESCRIPTION
## Summary
- Give edit-name buttons a white background and consistent width

## Testing
- `npm test`
- `npm run lint --prefix frontendClean` *(fails: 'setError' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_b_689a44ce2d4c83319dd0083191e80f5d